### PR TITLE
Refactor API endpoints without /api prefix

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -51,7 +51,7 @@ def admin_page():
     return render_template("admin.html")
 
 
-# -------------------- API JSON (sin /api prefix) --------------------
+# -------------------- API JSON (/admin/* endpoints) --------------------
 bp_admin_api = Blueprint("admin_api", __name__, url_prefix="/admin")
 
 

--- a/check_receipts_log.py
+++ b/check_receipts_log.py
@@ -106,7 +106,7 @@ def main():
             rows = cur.fetchall()
             print(f"✅ Consulta OK. Filas: {len(rows)}")
             if not rows:
-                print("ℹ️ No hay registros con ese filtro. Genera un POST /api/receipts y vuelve a correr este script.")
+                print("ℹ️ No hay registros con ese filtro. Genera un POST /receipts y vuelve a correr este script.")
                 return
 
             total_qty = 0

--- a/static/admin.js
+++ b/static/admin.js
@@ -1,5 +1,5 @@
 // static/admin.js
-// Endpoints JSON ahora viven bajo /admin/* (sin /api/admin)
+// API JSON vive bajo /admin/*
 const API_BASE = "/admin";
 
 /* ---------------- Utils ---------------- */

--- a/static/app.js
+++ b/static/app.js
@@ -1,6 +1,6 @@
 // static/app.js
-// Backends de negocio siguen en /api (orders, receipts). Si los mueves, cambia API_BASE = ''.
-const API_BASE = "/api";
+// Endpoints principales viven en la raíz (/orders, /receipts, ...).
+const API_BASE = "";
 
 const state = {
   user: null,

--- a/tests/smoke_render.py
+++ b/tests/smoke_render.py
@@ -14,8 +14,8 @@ def main():
     base = args.base.rstrip("/")
 
     # 1) LOGIN
-    print(f"[1] POST {base}/api/login")
-    r = requests.post(f"{base}/api/login", json={"username": args.user, "password": args.password}, timeout=60)
+    print(f"[1] POST {base}/login")
+    r = requests.post(f"{base}/login", json={"username": args.user, "password": args.password}, timeout=60)
     print("   status:", r.status_code)
     if r.status_code != 200:
         print("   body:", r.text)
@@ -31,19 +31,19 @@ def main():
     # Debug: muestra 20 chars del token
     print("   hdr Authorization:", f"Bearer {token[:20]}...")
 
-    # 2) /api/me (opcional, confirma que el token se acepta)
-    print(f"[2] GET  {base}/api/me")
-    r = requests.get(f"{base}/api/me", headers=headers, timeout=60)
+    # 2) /me (opcional, confirma que el token se acepta)
+    print(f"[2] GET  {base}/me")
+    r = requests.get(f"{base}/me", headers=headers, timeout=60)
     print("   status:", r.status_code)
     print("   body:", r.text[:300])
     if r.status_code != 200:
-        print("   ❌ El token no fue aceptado en /api/me")
+        print("   ❌ El token no fue aceptado en /me")
         sys.exit(2)
 
-    # 3) /api/orders
-    print(f"[3] GET  {base}/api/orders")
+    # 3) /orders
+    print(f"[3] GET  {base}/orders")
     params = {"due_from": args.due_from, "due_to": args.due_to, "page": "1", "pageSize": "10"}
-    r = requests.get(f"{base}/api/orders", params=params, headers=headers, timeout=60)
+    r = requests.get(f"{base}/orders", params=params, headers=headers, timeout=60)
     print("   url:", r.url)
     print("   status:", r.status_code)
     print("   body:", r.text[:500])
@@ -54,8 +54,8 @@ def main():
     # 4) (opcional) si quieres probar detalle rápido:
     try:
         doc_entry = (r.json().get("data") or [])[0]["docEntry"]
-        print(f"[4] GET  {base}/api/orders/{doc_entry}")
-        detail_url = f"{base}/api/orders/{doc_entry}"
+        print(f"[4] GET  {base}/orders/{doc_entry}")
+        detail_url = f"{base}/orders/{doc_entry}"
         if args.whs:
             detail_url += f"?whsCode={args.whs}"
         r2 = requests.get(detail_url, headers=headers, timeout=60)


### PR DESCRIPTION
## Summary
- expose the auth blueprint at the root and add shared helpers to validate JWT access
- move recepciones endpoints to the root and serve admin JSON under /admin/* while keeping security headers/CORS aligned
- update frontend scripts, tools, and tests to call the updated endpoints

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08f998d00832295ee24a8e2d5cf86