### PR TITLE
Add login view with cookie-based auth

### DIFF
--- a/static/login.js
+++ b/static/login.js
@@ -1,0 +1,65 @@
+// static/login.js
+
+function $(id) { return document.getElementById(id); }
+
+async function submitLogin(ev) {
+  ev.preventDefault();
+  const username = $("username")?.value.trim();
+  const password = $("password")?.value || "";
+  const msg = $("loginMsg");
+  const btn = $("btnLogin");
+
+  if (msg) { msg.textContent = ""; msg.classList.remove("error"); }
+
+  if (!username || !password) {
+    if (msg) {
+      msg.textContent = "Usuario y contraseña son requeridos";
+      msg.classList.add("error");
+    }
+    return;
+  }
+
+  if (btn) btn.disabled = true;
+  if (msg) { msg.textContent = "Autenticando..."; msg.classList.remove("error"); }
+
+  try {
+    const res = await fetch("/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password })
+    });
+
+    const contentType = res.headers.get("content-type") || "";
+    let payload = null;
+    if (contentType.includes("application/json")) {
+      payload = await res.json();
+    } else {
+      payload = await res.text();
+    }
+
+    if (!res.ok) {
+      const message = (payload && payload.error && payload.error.message) || payload?.message || payload || "Error al iniciar sesión";
+      throw new Error(message);
+    }
+
+    if (msg) {
+      msg.textContent = "Acceso concedido, redirigiendo...";
+      msg.classList.remove("error");
+    }
+
+    setTimeout(() => { window.location.href = "/"; }, 200);
+  } catch (err) {
+    if (msg) {
+      msg.textContent = `❌ ${err.message || err}`;
+      msg.classList.add("error");
+    }
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  const form = $("loginForm");
+  form?.addEventListener("submit", submitLogin);
+  $("username")?.focus();
+});

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>Portal Recepciones – Iniciar sesión</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root{
+      --bersa-azul: #0B2241;
+      --bersa-rojo: #E62D33;
+      --bg: #f6f7fb;
+      --card: #ffffff;
+      --text: #0b1221;
+      --muted: #6b7280;
+      --border: #e8ecf2;
+      --accent: #FF9C27;
+    }
+    *{ box-sizing:border-box; }
+    body{
+      margin:0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      background: radial-gradient(circle at top, rgba(11,34,65,0.18), transparent 55%), var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding: 24px;
+    }
+    .card{
+      width: min(420px, 100%);
+      background: var(--card);
+      border-radius: 16px;
+      border:1px solid var(--border);
+      box-shadow: 0 18px 45px rgba(11,34,65,0.12);
+      padding: 32px 28px;
+    }
+    h1{ margin-top:0; font-size: 26px; }
+    label{ display:block; font-size:13px; color: var(--muted); margin-bottom:4px; }
+    input{
+      width:100%;
+      padding: 11px 12px;
+      border-radius: 10px;
+      border:1px solid #d7dbe3;
+      font-size:15px;
+      margin-bottom:14px;
+    }
+    input:focus{
+      outline:none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(255,156,39,0.25);
+    }
+    button{
+      width:100%;
+      padding: 12px 14px;
+      border-radius: 10px;
+      border:none;
+      font-size:15px;
+      font-weight:600;
+      background: var(--bersa-azul);
+      color:#fff;
+      cursor:pointer;
+      transition: filter .18s ease;
+    }
+    button:hover{ filter: brightness(1.08); }
+    button:disabled{ opacity: .65; cursor: wait; }
+    .status{
+      margin-top: 12px;
+      font-size: 13px;
+      color: var(--muted);
+      min-height: 20px;
+    }
+    .status.error{ color: var(--bersa-rojo); }
+  </style>
+</head>
+<body>
+  <section class="card">
+    <h1>Recepciones</h1>
+    <p style="margin-top:-6px; color:var(--muted);">Inicia sesión con tu usuario de almacén.</p>
+    <form id="loginForm" autocomplete="off">
+      <label for="username">Usuario</label>
+      <input id="username" name="username" autocomplete="username" required />
+      <label for="password">Contraseña</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required />
+      <button id="btnLogin" type="submit">Ingresar</button>
+    </form>
+    <div id="loginMsg" class="status"></div>
+  </section>
+  <script src="/static/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a login page route that renders the HTML form when users hit `/login`
- issue and clear the JWT cookie during login/logout so the SPA can call protected endpoints
- build the login UI and client script that posts credentials and redirects into the recepciones dashboard

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d097e783788322bb0ab43274092be3